### PR TITLE
fix: use ConcurrentBag and remove async/await in loop

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -63,7 +63,7 @@ jobs:
       with:
         dotnet-version: 8.0.x
     - name: Test the solution
-      run: dotnet test TourGuide.sln --logger trx --results-directory ./TestResults
+      run: dotnet test TourGuide.sln --no-build --verbosity normal --logger trx --results-directory ./TestResults
     - name: Test Report
       uses: dorny/test-reporter@v1
       if: success() || failure()

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -62,8 +62,12 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
+    - name: Restore .NET tools
+      run: dotnet tool restore
+    - name: Restore dependencies
+      run: dotnet restore --locked-mode
     - name: Test the solution
-      run: dotnet test TourGuide.sln --no-build --verbosity normal --logger trx --results-directory ./TestResults
+      run: dotnet test TourGuide.sln --logger trx --results-directory ./TestResults
     - name: Test Report
       uses: dorny/test-reporter@v1
       if: success() || failure()

--- a/Api/Services/RewardsService.cs
+++ b/Api/Services/RewardsService.cs
@@ -49,7 +49,7 @@ public class RewardsService : IRewardsService
         HashSet<string> existingRewardAttractions = new(user.UserRewards.Select(r => r.Attraction.AttractionName));
 
         ConcurrentBag<UserReward> rewardsToAdd = [];
-        await Parallel.ForEachAsync(userVisitedLocations, async (visitedLocation, token) =>
+        Parallel.ForEach(userVisitedLocations, visitedLocation =>
         {
             foreach (Attraction attraction in getAllAttractions)
             {

--- a/TourGuideTest/PerformanceTest.cs
+++ b/TourGuideTest/PerformanceTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Concurrent;
+using System.Diagnostics;
 using GpsUtil.Location;
 using TourGuide.Users;
 using Xunit.Abstractions;
@@ -74,7 +75,7 @@ namespace TourGuideTest
             allUsers.ForEach(u => u.AddToVisitedLocations(new VisitedLocation(u.UserId, attraction, DateTime.Now)));
 
             // Create a list of tasks to run CalculateRewardsAsync in parallel
-            List<Task> tasks = [];
+            ConcurrentBag<Task> tasks = [];
             allUsers.ForEach(u => tasks.Add(_fixture.RewardsService.CalculateRewardsAsync(u)));
 
             // Await for all tasks to be completed


### PR DESCRIPTION
fix CalculateRewardsAsync get sometimes System.InvalidOperationException Collection was modified enumeration operation may not execute #24
improve consistency of the tests and performances.